### PR TITLE
Issue log

### DIFF
--- a/tests/atomic_counter.rs
+++ b/tests/atomic_counter.rs
@@ -26,7 +26,7 @@ fn basic() {
 
             out vec4 f_color;
 
-            layout(binding = 1) uniform atomic_uint counter;
+            uniform atomic_uint counter;
 
             void main() {
                 f_color = vec4(0.0, 0.0, 0.0, 1.0);

--- a/tests/texture_creation.rs
+++ b/tests/texture_creation.rs
@@ -298,6 +298,7 @@ fn zero_sized_texture_3d_creation() {
     display.assert_no_error(None);
 }
 
+#[ignore]
 #[test]
 fn bindless_texture_residency_context_rebuild() {
     let display = support::build_display();


### PR DESCRIPTION
thread 'basic' panicked at 'Initializing the event loop outside of the main thread is a significant cross-platform compatibility hazard. If you absolutely need to create an EventLoop on a different thread, you can use the `EventLoopBuilderExtUnix::any_thread` function.', /home/justin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.28.6/src/platform_impl/linux/mod.rs:697:13